### PR TITLE
fix: blocking egg startup if there is no partial directory

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,10 +8,11 @@ const COMPILE = Symbol('compile');
 
 module.exports = app => {
   const partials = loadPartial(app);
-  for (const key of Object.keys(partials)) {
-    handlebars.registerPartial(key, partials[key]);
+  if (partials) {
+    for (const key of Object.keys(partials)) {
+      handlebars.registerPartial(key, partials[key]);
+    }
   }
-
   class HandlebarsView {
     constructor(ctx) {
       this.app = ctx.app;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
n/a

##### Description of change
<!-- Provide a description of the change below this comment. -->
This is a minor fix. Tests passed and there is no need to change documentations.
Basically if user didn't create view/partials directory, loadPartials function will return undefined, which blocks egg start up.
I mentioned the issue here: https://github.com/eggjs/egg/issues/1967
